### PR TITLE
Fixes #11

### DIFF
--- a/boshctl
+++ b/boshctl
@@ -111,12 +111,14 @@ login_via_opsmgr() {
 }
 
 login() {
+  local director_url=
   if ! is_director_targeted; then
-    local director_url=
     read -r -p "Director URL: " director_url
     bosh -n --ca-cert /var/tempest/workspaces/default/root_ca_certificate target $director_url
-    bosh2 alias-env pcf -e $director_url --ca-cert=/var/tempest/workspaces/default/root_ca_certificate
+  else
+    local director_url=$(bosh target | grep -E -o '([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)')
   fi
+  bosh2 alias-env pcf -e $director_url --ca-cert=/var/tempest/workspaces/default/root_ca_certificate
   if is_opsman_locked; then
     local passphrase=
     read -r -s -p "Ops Manager Decryption Passphrase: " passphrase


### PR DESCRIPTION
Error occurred if user had already targeted bosh before running boshctl for the first time. Fix checks for this situation and targets the bosh2 env to get bosh and bosh2 in sync.